### PR TITLE
feat: Add Akash video to clients section & fix thumbnail 404s

### DIFF
--- a/src/data/activities.js
+++ b/src/data/activities.js
@@ -80,6 +80,7 @@ export const activities = [
       { src: 'videos/CLAUDIA', type: 'video', caption: 'Private PT Training Claudia' },
       { src: 'videos/LAURA', type: 'video', caption: 'Private PT Training Laura' },
       { src: 'videos/CLAUDIA_', type: 'video', caption: 'Private PT Training Claudia_' },
+      { src: 'videos/Akash', type: 'video', caption: 'Private PT Training Akash' },
     ]
   },
   {

--- a/src/pages/MyActivitiesPage.vue
+++ b/src/pages/MyActivitiesPage.vue
@@ -252,7 +252,7 @@ const getVideoThumbnailUrl = (path, width) => {
   const transforms = width ? `f_auto,q_auto,w_${width},so_auto` : 'f_auto,q_auto,so_auto';
   // Strip extension and replace with .jpg for Cloudinary image-from-video delivery
   const cleanPath = path.replace(/\.[^/.]+$/, "");
-  return `${CLOUD_IMG}/${transforms}/gym-yohanes/${cleanPath}.jpg`;
+  return `${CLOUD_VID}/${transforms}/gym-yohanes/${cleanPath}.jpg`;
 };
 
 // ==========================================


### PR DESCRIPTION
Closes #11. Closes #12.

This PR:
1. Adds the requested Akash video (`videos/Akash.mp4` on Cloudinary) to the end of the `photos` list in the "Clients Sessions" event in `src/data/activities.js`.
2. Fixes a bug in `src/pages/MyActivitiesPage.vue` where video thumbnails were failing to load (404) because they were requested from the Cloudinary image delivery prefix (`image/upload`) instead of the video delivery prefix (`video/upload`).